### PR TITLE
enable no-plusplus rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+test/unit/coverage/lcov-report/*.js
+docs/**/*.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ module.exports = {
     "no-multiple-empty-lines": 0,
     "no-nested-ternary": 0,
     "no-param-reassign": 0,
-    "no-plusplus": 0,
     "no-prototype-builtins": 0,
     "no-redeclare": 0,
     "no-restricted-globals": 0,

--- a/build/check-versions.js
+++ b/build/check-versions.js
@@ -1,54 +1,56 @@
-'use strict'
-const chalk = require('chalk')
-const semver = require('semver')
-const packageConfig = require('../package.json')
-const shell = require('shelljs')
+"use strict";
+const chalk = require("chalk");
+const semver = require("semver");
+const packageConfig = require("../package.json");
+const shell = require("shelljs");
 
-function exec (cmd) {
-  return require('child_process').execSync(cmd).toString().trim()
+function exec(cmd) {
+  return require("child_process")
+    .execSync(cmd)
+    .toString()
+    .trim();
 }
 
 const versionRequirements = [
   {
-    name: 'node',
+    name: "node",
     currentVersion: semver.clean(process.version),
     versionRequirement: packageConfig.engines.node
   }
-]
+];
 
-if (shell.which('npm')) {
+if (shell.which("npm")) {
   versionRequirements.push({
-    name: 'npm',
-    currentVersion: exec('npm --version'),
+    name: "npm",
+    currentVersion: exec("npm --version"),
     versionRequirement: packageConfig.engines.npm
-  })
+  });
 }
 
-module.exports = function () {
-  const warnings = []
-
-  for (let i = 0; i < versionRequirements.length; i++) {
-    const mod = versionRequirements[i]
-
-    if (!semver.satisfies(mod.currentVersion, mod.versionRequirement)) {
-      warnings.push(mod.name + ': ' +
-        chalk.red(mod.currentVersion) + ' should be ' +
-        chalk.green(mod.versionRequirement)
-      )
-    }
-  }
+module.exports = function() {
+  const warnings = versionRequirements.reduce((warnings, mod) => {
+    if (semver.satisfies(mod.currentVersion, mod.versionRequirement))
+      return warnings;
+    return [
+      ...warnings,
+      `${mod.name}: ${chalk.red(mod.currentVersion)} should be ${chalk.green(
+        mod.versionRequirement
+      )}`
+    ];
+  }, []);
 
   if (warnings.length) {
-    console.log('')
-    console.log(chalk.yellow('To use this template, you must update following to modules:'))
-    console.log()
+    console.log("");
+    console.log(
+      chalk.yellow(
+        "To use this template, you must update following to modules:"
+      )
+    );
+    console.log();
 
-    for (let i = 0; i < warnings.length; i++) {
-      const warning = warnings[i]
-      console.log('  ' + warning)
-    }
+    warnings.forEach(warning => console.log(`  ${warning}`));
 
-    console.log()
-    process.exit(1)
+    console.log();
+    process.exit(1);
   }
-}
+};

--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -1,8 +1,8 @@
 {
-  "env": { 
+  "env": {
     "mocha": true
   },
-  "globals": { 
+  "globals": {
     "expect": true,
     "sinon": true
   }


### PR DESCRIPTION
* Reenabled the `no-plusplus` rule and fixed its usage in `build/check-versions.js`
* Adds .eslintignore, where you can specify folders (do you really wanna ignore `build/` though? If it's not generated...)
* Would you be open to configuring Prettier for this repository?