### PR TITLE
Add .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["babel-plugin-transform-object-rest-spread"]
+}


### PR DESCRIPTION
#78 Added .babelrc file with the rest spread plugin.

The plugin is on `package.json`, however if you try to run on dev mode a syntax error still appears and won't compile; after adding the `.babelrc` the app runs without problem.